### PR TITLE
set aco_gtls_co to main_co after creating main_co

### DIFF
--- a/aco.c
+++ b/aco.c
@@ -355,6 +355,7 @@ aco_t* aco_create(
         p->fp = fp;
         p->share_stack = NULL;
         p->save_stack.ptr = NULL;
+        aco_gtls_co = p;
         return p;
     }
     assert(0);


### PR DESCRIPTION
After creating `main_co`, set `aco_gtls_co` to `main_co`, so that `aco_get_co()` can return the proper result (rather than `NULL`).