### PR TITLE
Add aco_yield_to()

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Note: Please use [releases][github-release] instead of the `master` to build the
       * [aco_create](#aco_create)
       * [aco_resume](#aco_resume)
       * [aco_yield](#aco_yield)
+      * [aco_yield_to](#aco_yield_to)
       * [aco_get_co](#aco_get_co)
       * [aco_get_arg](#aco_get_arg)
       * [aco_exit](#aco_exit)
@@ -374,6 +375,18 @@ void aco_yield();
 Yield the execution of `co` and resume `co->main_co`. The caller of this function must be a non-main co. And `co->main_co` must not be NULL.
 
 After the call of `aco_yield`, we name the state of the caller — `co` as "yielded".
+
+## aco_yield_to
+
+```c
+void aco_yield_to(aco_t* resume_co);
+```
+
+Yield the execution of `co` and resume `resume_co`. The caller of this function must be a non-main co (i.e. `co->main_co` is not NULL). If `co` is different of `resume_co`, they cannot share the same stack and `co->main_co` and `resume_co->main_co` must be equal.
+
+After the call of `aco_yield_to`, we name the state of the caller — `co` as "yielded".
+
+`aco_yield_to()` is useful when a non-main co wants to yield to another co with a single context switch. Without `aco_yield_to()`, one has to go through two switches: one switch back to main co and another switch to the desired non-main co.
 
 ## aco_get_co
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ One of the rules in libaco is to call `aco_exit()` to terminate the execution of
 
 You could also define your own protector to substitute the default one (to do some customized "last words" stuff). But no matter in what case, the process will be aborted after the protector was executed. The `test_aco_tutorial_5.c` shows how to define the customized last word function.
 
-The last example is a simple coroutine scheduler in `test_aco_tutorial_6.c`.
+The example `test_aco_tutorial_6.c` is a simple coroutine scheduler. And the last example, namely `test_aco_tutorial_7.c`, is the same scheduler using `aco_yield_to`.
 
 # API
 

--- a/aco.h
+++ b/aco.h
@@ -186,6 +186,9 @@ extern __thread aco_t* aco_gtls_co;
 aco_attr_no_asan
 extern void aco_resume(aco_t* resume_co);
 
+aco_attr_no_asan
+void aco_yield_to(aco_t* resume_co);
+
 //extern void aco_yield1(aco_t* yield_co);
 #define aco_yield1(yield_co) do {             \
     aco_assertptr((yield_co));                    \

--- a/make.sh
+++ b/make.sh
@@ -30,6 +30,7 @@ test_aco_tutorial_3 -lpthread
 test_aco_tutorial_4
 test_aco_tutorial_5
 test_aco_tutorial_6
+test_aco_tutorial_7
 test_aco_synopsis
 test_aco_benchmark
 '''

--- a/test_aco_tutorial_7.c
+++ b/test_aco_tutorial_7.c
@@ -1,0 +1,112 @@
+// Copyright 2018 Sen Han <00hnes@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A pretty simple scheduler demo using aco_yield_to().
+
+#include "aco.h"    
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "aco_assert_override.h"
+
+size_t curr_co_amount;
+size_t curr_co_index;
+aco_t** coarray;
+
+void yield_to_next_co(){
+    assert(curr_co_amount > 0);
+    curr_co_index = (curr_co_index + 1) % curr_co_amount;
+    aco_yield_to(coarray[curr_co_index]);
+}
+
+void co_fp0(){
+    int ct = 0;
+    int loop_ct = (int)((uintptr_t)(aco_get_co()->arg));
+    if(loop_ct < 0){
+        loop_ct = 0;
+    }
+    while(ct < loop_ct){
+        yield_to_next_co();
+        ct++;
+    }
+    aco_exit();
+}
+
+int main() {
+    aco_thread_init(NULL);
+
+    time_t seed_t = time(NULL);
+    assert((time_t)-1 != seed_t);
+    srand(seed_t);
+
+    size_t co_amount = 100;
+    curr_co_amount = co_amount;
+
+    // create co
+    assert(co_amount > 0);
+    aco_t* main_co = aco_create(NULL, NULL, 0, NULL, NULL);
+    // NOTE: size_t_safe_mul
+    coarray = (aco_t**) malloc(sizeof(void*) * co_amount);
+    assertptr(coarray);
+    memset(coarray, 0, sizeof(void*) * co_amount);
+    size_t ct = 0;
+    while(ct < co_amount){
+        aco_share_stack_t* private_sstk = aco_share_stack_new2(
+            0, ct % 2
+        );
+        coarray[ct] = aco_create(
+            main_co, private_sstk, 0, co_fp0,
+            (void*)((uintptr_t)rand() % 1000)
+        );
+        private_sstk = NULL;
+        ct++;
+    }
+
+    // naive scheduler
+    printf("scheduler start: co_amount:%zu\n", co_amount);
+    aco_t* curr_co = coarray[curr_co_index];
+    while(curr_co_amount > 0){
+        aco_resume(curr_co);
+        // Update curr_co because aco_yield_to() may have changed it
+        curr_co = coarray[curr_co_index];
+        assert(curr_co->is_end != 0);
+        printf("aco_destroy: co currently at:%zu\n", curr_co_index);
+        aco_share_stack_t* private_sstk = curr_co->share_stack;
+        aco_destroy(curr_co);
+        aco_share_stack_destroy(private_sstk);
+        private_sstk = NULL;
+        curr_co_amount--;
+        if(curr_co_index < curr_co_amount){
+            coarray[curr_co_index] = coarray[curr_co_amount];
+        }else{
+            curr_co_index = 0;
+        }
+        coarray[curr_co_amount] = NULL;
+        curr_co = coarray[curr_co_index];
+    }
+
+    // co cleaning
+    ct = 0;
+    while(ct < co_amount){
+        assert(coarray[ct] == NULL);
+        ct++;
+    }
+    aco_destroy(main_co);
+    main_co = NULL;
+    free(coarray);
+
+    printf("sheduler exit");
+    
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces `aco_yield_to()` that enables a non-main co to yield to another co with a single context switch.

The first patch, namely **add aco_yield_to()**, seems a little complicated because part of the code of `aco_resume()` is moved to a new auxiliary function called `aco_own_stack()` to avoid duplicating code at `aco_yield_to()`. Ignoring this code movement, the additions are straightforward.

The second patch adds `test_aco_tutorial_7.c` to test and show how to use `aco_yield_to()`.

This pull request closes #31