### PR TITLE
Added Dependencies Before Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ The global C macro `ACO_USE_ASAN` would enable the friendly support of [Address 
 
 To build the test suites of libaco:
 
+### Default Build Dependencies
+* valgrind development library
+* glibc 32 bit development library 
+
 ```bash
 $ mkdir output
 $ bash make.sh


### PR DESCRIPTION
This PR is definitely nit-picking over user experience.

Adding build dependencies before build instructions allows the user to build it successfully on the first try.  There are instructions further on that reveal that those dependencies exist, but some people (like me) are impatient and jump right into building it without reading everything.

Thoughts?