### PR TITLE
Add aco_is_in_main_co() function

### DIFF
--- a/aco.c
+++ b/aco.c
@@ -490,3 +490,8 @@ void aco_destroy(aco_t* co){
         free(co);
     }
 }
+
+int aco_is_in_main_co(void){
+    if(aco_gtls_co->main_co == NULL || aco_gtls_co == NULL) return 1;
+    else return 0;
+}

--- a/aco.h
+++ b/aco.h
@@ -186,6 +186,9 @@ extern __thread aco_t* aco_gtls_co;
 aco_attr_no_asan
 extern void aco_resume(aco_t* resume_co);
 
+/* Return 1 if the function is directly called by main co; 0 is called by non-main co*/
+extern int aco_is_in_main_co(void);
+
 //extern void aco_yield1(aco_t* yield_co);
 #define aco_yield1(yield_co) do {             \
     aco_assertptr((yield_co));                    \


### PR DESCRIPTION
To identify whether the function call is directly from main co or
from non-main co, one function is added to support reveal the
status.

aco_gtls_co->main_co is used to identify the current status,
because main_co pointer is NULL in main_co status